### PR TITLE
Added an option to allow the scripts to be added only to specific pages

### DIFF
--- a/lib/http-endpoint.php
+++ b/lib/http-endpoint.php
@@ -5,6 +5,7 @@ add_action( 'admin_init', 'register_sls_forms_ext_settings' );
 function register_sls_forms_ext_settings() {
   register_setting( 'wp-sls-forms-settings-group', 'wp_sls_forms_endpoint' );
   register_setting( 'wp-sls-forms-settings-group', 'wp_sls_forms_redirect' );
+  register_setting( 'wp-sls-forms-settings-group', 'wp_sls_forms_pages' );
 }
 
 // Create Options Page

--- a/lib/modules/endpoint-form.php
+++ b/lib/modules/endpoint-form.php
@@ -21,6 +21,13 @@
             <input name="wp_sls_forms_redirect" type="text" aria-describedby="serverless-forms-redirect" value="<?php echo get_option('wp_sls_forms_redirect'); ?>" class="regular-text code">
           </td>
         </tr>
+        <tr valign="top">
+          <th scope="row">Pages</th>
+          <td>
+            <input name="wp_sls_forms_pages" type="text" aria-describedby="serverless-forms-pages" value="<?php echo get_option('wp_sls_forms_pages'); ?>" class="regular-text code" placeholder="contact,message">
+            <p>(Leave blank to add scripts to all pages)</p>
+          </td>
+        </tr>
       </table>
       <?php submit_button(); ?>
     </form>

--- a/wp-serverless-forms.php
+++ b/wp-serverless-forms.php
@@ -32,19 +32,23 @@ function wp_sls_forms() {
  */
 
 function wp_sls_forms_js() {
-	$shifter_js = plugins_url( 'assets/js/main.js', __FILE__ );
+  $pages_csv = esc_attr(get_option('wp_sls_forms_pages'));
+  $pgs = explode(',', $pages_csv, 50);
+  
+  if (empty($pages_csv) || is_page($pgs)) {
+    $shifter_js = plugins_url( 'assets/js/main.js', __FILE__ );
 
-	// Main.js
-	wp_register_script("wp-sls-forms-js", $shifter_js);
-	$args = array(
-		'is_user_logged_in' => is_user_logged_in(),
-		'admin_email' => get_option('admin_email'),
-		'blogname' => get_option('blogname'),
-		'wp_sls_forms_endpoint' => get_option('wp_sls_forms_endpoint'),
-		'wp_sls_forms_redirect' => get_option('wp_sls_forms_redirect')
-	);
-	wp_localize_script( 'wp-sls-forms-js', 'wp', $args );
-	wp_enqueue_script("wp-sls-forms-js");
+    // Main.js
+    wp_register_script("wp-sls-forms-js", $shifter_js);
+    $args = array(
+      'is_user_logged_in' => is_user_logged_in(),
+      'blogname' => get_option('blogname'),
+      'wp_sls_forms_endpoint' => get_option('wp_sls_forms_endpoint'),
+      'wp_sls_forms_redirect' => get_option('wp_sls_forms_redirect'),
+    );
+    wp_localize_script( 'wp-sls-forms-js', 'wp', $args );
+    wp_enqueue_script("wp-sls-forms-js");
+  }
 }
 
 add_action('wp_enqueue_scripts', 'wp_sls_forms_js' );


### PR DESCRIPTION
New setting allows the script and associated code to be only added to specific pages. For simple sites with a single contact form adding scripts to all pages is unnecessary. 
Non Breaking because the default value is empty and this preserves existing behaviour of adding the script to all pages.

I'm not a PHP ninja so appreciate a code review